### PR TITLE
Force Resource limits to Strings

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -271,7 +271,7 @@ const createDeployment = async (project, options) => {
         localPod.spec.containers[0].env.push({ name: 'FORGE_LICENSE_TYPE', value: 'ee' })
     }
     if (stack.memory) {
-        localPod.spec.containers[0].env.push({ name: 'FORGE_MEMORY_LIMIT', value: stack.memory.toString() })
+        localPod.spec.containers[0].env.push({ name: 'FORGE_MEMORY_LIMIT', value: `${stack.memory}` })
     }
     if (stack.cpu) {
         localPod.spec.containers[0].env.push({ name: 'FORGE_CPU_LIMIT', value: stack.cpu.toString() })

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -271,10 +271,10 @@ const createDeployment = async (project, options) => {
         localPod.spec.containers[0].env.push({ name: 'FORGE_LICENSE_TYPE', value: 'ee' })
     }
     if (stack.memory) {
-        localPod.spec.containers[0].env.push({ name: 'FORGE_MEMORY_LIMIT', value: stack.memory })
+        localPod.spec.containers[0].env.push({ name: 'FORGE_MEMORY_LIMIT', value: stack.memory.toString() })
     }
     if (stack.cpu) {
-        localPod.spec.containers[0].env.push({ name: 'FORGE_CPU_LIMIT', value: stack.cpu })
+        localPod.spec.containers[0].env.push({ name: 'FORGE_CPU_LIMIT', value: stack.cpu.toString() })
     }
 
     const credentialSecret = await project.getSetting('credentialSecret')

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -274,7 +274,7 @@ const createDeployment = async (project, options) => {
         localPod.spec.containers[0].env.push({ name: 'FORGE_MEMORY_LIMIT', value: `${stack.memory}` })
     }
     if (stack.cpu) {
-        localPod.spec.containers[0].env.push({ name: 'FORGE_CPU_LIMIT', value: stack.cpu.toString() })
+        localPod.spec.containers[0].env.push({ name: 'FORGE_CPU_LIMIT', value: `${stack.cpu}` })
     }
 
     const credentialSecret = await project.getSetting('credentialSecret')


### PR DESCRIPTION
fixes #121

## Description

<!-- Describe your changes in detail -->
Values for resource limits are added as numbers but later versions of K8s require all env vars to be strings.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#121 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

