### PR TITLE
#3174: Enable Multi-Core CPU Support for Node-RED Projects

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -695,10 +695,10 @@ module.exports = {
             stack: {
                 properties: {
                     cpu: {
-                        label: 'CPU Cores (%)',
-                        validate: '^([1-9][0-9]?|100)$',
-                        invalidMessage: 'Invalid value - must be a number between 1 and 100',
-                        description: 'How much of a single CPU core each Project should receive'
+                        label: 'CPU Cores (in 1/100th units)',
+                        validate: '^([1-9][0-9]{0,2}|1000)$',
+                        invalidMessage: 'Invalid value - must be a number between 1 and 1000, where 100 represents 1 CPU core',
+                        description: 'Defines the CPU resources each Project should receive, in units of 1/100th of a CPU core. 100 equates to 1 CPU core'
                     },
                     memory: {
                         label: 'Memory (MB)',


### PR DESCRIPTION
## Description
As discussed in https://github.com/FlowFuse/flowfuse/issues/3174, allow the Project instance CPU quota to exceed 1 CPU (with this PR, up to 10 CPU)

## Related Issue(s)
https://github.com/FlowFuse/flowfuse/issues/3174

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
    Looks like there's no test specific to this regex?
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

