### PR TITLE
Typo, extra `_` in option name

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -605,7 +605,7 @@ module.exports = {
         this._namespace = this._app.config.driver.options.projectNamespace || 'flowforge'
         this._k8sDelay = this._app.config.driver.options.k8sDelay || 1000
         this._k8sRetries = this._app.config.driver.options.k8sRetries || 10
-        this._certManagerIssuer = this._app.config.driver.options._certManagerIssuer
+        this._certManagerIssuer = this._app.config.driver.options.certManagerIssuer
 
         const kc = new k8s.KubeConfig()
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Added an extra `_`

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

