### PR TITLE
Fix containers resource requests missing last s

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -102,7 +102,7 @@ const deploymentTemplate = {
                 containers: [
                     {
                         resources: {
-                            request: {
+                            requests: {
                                 // 10th of a core
                                 cpu: '100m',
                                 memory: '128Mi'
@@ -315,9 +315,9 @@ const createDeployment = async (project, options) => {
     }
 
     if (stack.memory && stack.cpu) {
-        localPod.spec.containers[0].resources.request.memory = `${stack.memory}Mi`
+        localPod.spec.containers[0].resources.requests.memory = `${stack.memory}Mi`
         localPod.spec.containers[0].resources.limits.memory = `${stack.memory}Mi`
-        localPod.spec.containers[0].resources.request.cpu = `${stack.cpu * 10}m`
+        localPod.spec.containers[0].resources.requests.cpu = `${stack.cpu * 10}m`
         localPod.spec.containers[0].resources.limits.cpu = `${stack.cpu * 10}m`
     }
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Typo, missing an `s` from the end of `requests`

https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#example-1

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

