### PR TITLE
Add log passthrough support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ driver:
     certManagerIssuer: lets-encrypt
     k8sDelay: 1000
     k8sRetries: 10
+    logPassthrough: true
 ```
 
 - `registry` is the Docker Registry to load Stack Containers from
@@ -32,6 +33,7 @@ AWS EKS specific annotation for ALB Ingress.
 - `certManagerIssuer` name of the ClusterIssuer to use to create HTTPS certs for instances (default not set)
 - `k8sRetries` how many times to retry actions against the K8s API
 - `k8sDelay` how long to wait (in ms) between retries to the K8s API
+- `logPassthrough` Have Node-RED logs printed in JSON format to container stdout (default false)
 
 Expects to pick up K8s credentials from the environment
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -283,7 +283,7 @@ const createDeployment = async (project, options) => {
     }
 
     if (this._logPassthrough) {
-        localPod.spec.containers[0].env.push({ name: "FORGE_LOG_PASSTHROUGH", value: "true" })
+        localPod.spec.containers[0].env.push({ name: 'FORGE_LOG_PASSTHROUGH', value: 'true' })
     }
 
     if (this._app.config.driver.options.projectSelector) {

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -606,11 +606,11 @@ module.exports = {
         this._projects = {}
         this._options = options
 
-        this._namespace = this._app.config.driver.options.projectNamespace || 'flowforge'
-        this._k8sDelay = this._app.config.driver.options.k8sDelay || 1000
-        this._k8sRetries = this._app.config.driver.options.k8sRetries || 10
-        this._certManagerIssuer = this._app.config.driver.options.certManagerIssuer
-        this._logPassthrough = this._app.config.driver.options.logPassthrough || false
+        this._namespace = this._app.config.driver.options?.projectNamespace || 'flowforge'
+        this._k8sDelay = this._app.config.driver.options?.k8sDelay || 1000
+        this._k8sRetries = this._app.config.driver.options?.k8sRetries || 10
+        this._certManagerIssuer = this._app.config.driver.options?.certManagerIssuer
+        this._logPassthrough = this._app.config.driver.options?.logPassthrough || false
 
         const kc = new k8s.KubeConfig()
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -282,6 +282,10 @@ const createDeployment = async (project, options) => {
         localPod.spec.containers[0].env.push({ name: 'FORGE_NR_SECRET', value: credentialSecret })
     }
 
+    if (this._logPassthrough) {
+        localPod.spec.containers[0].env.push({ name: "FORGE_LOG_PASSTHROUGH", value: "true" })
+    }
+
     if (this._app.config.driver.options.projectSelector) {
         localPod.spec.nodeSelector = this._app.config.driver.options.projectSelector
     }
@@ -606,6 +610,7 @@ module.exports = {
         this._k8sDelay = this._app.config.driver.options.k8sDelay || 1000
         this._k8sRetries = this._app.config.driver.options.k8sRetries || 10
         this._certManagerIssuer = this._app.config.driver.options.certManagerIssuer
+        this._logPassthrough = this._app.config.driver.options.logPassthrough || false
 
         const kc = new k8s.KubeConfig()
 


### PR DESCRIPTION
part of FlowFuse/flowfuse#3324

## Description

<!-- Describe your changes in detail -->
Allows NR Pods to be configured to output NR logs to stdout

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#3324

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

