### PR TITLE
Rename default stack container

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -1156,7 +1156,7 @@ module.exports = {
         const properties = {
             cpu: 10,
             memory: 256,
-            container: 'flowforge/node-red',
+            container: 'flowfuse/node-red',
             ...this._app.config.driver.options?.default_stack
         }
 


### PR DESCRIPTION
part of FlowFuse/admin#212

## Description

<!-- Describe your changes in detail -->
Rename from flowforge/node-red to flowfuse/node-red

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/admin#212

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

