### PR TITLE
Allow pods to use 128m extra memory for npm

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -324,7 +324,8 @@ const createDeployment = async (project, options) => {
 
     if (stack.memory && stack.cpu) {
         localPod.spec.containers[0].resources.requests.memory = `${stack.memory}Mi`
-        localPod.spec.containers[0].resources.limits.memory = `${stack.memory}Mi`
+        // increase limit to give npm more room to run in
+        localPod.spec.containers[0].resources.limits.memory = `${stack.memory + 128}Mi`
         localPod.spec.containers[0].resources.requests.cpu = `${stack.cpu * 10}m`
         localPod.spec.containers[0].resources.limits.cpu = `${stack.cpu * 10}m`
     }


### PR DESCRIPTION
part of https://github.com/FlowFuse/flowfuse/issues/3630

## Description

<!-- Describe your changes in detail -->
This allows npm/nr-launcher to use up to 128m more than the Stack memory constraint.

Since the nr-launcher set the --max-old-space setting to 75% of the Stack memory this will limit the Node-RED process to not use this extra memory allowance.

As this is set as the k8s resource `limits` and not the `requests` it should not impact the number of Instances that can be scheduled on a node.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/issues/3630

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

