### PR TITLE
Persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ AWS EKS specific annotation for ALB Ingress. or `openshift` to allow running on 
 - `customHostname.ingressClass` Name of the IngressClass to use to expose the custom hostname (default not set)
 - `storage.enabled` Mounts a persistent volume on `/data/storage` (default false)
 - `storage.storageClass` Name of StorageClass to use to allocate the volume (default not set)
+- `storage.storageClassEFSTag` Used instead of `storage.storageClass` when needing to shard across multiple EFS file systems (default not set)
 - `storage.size` Size of the volume to request (default not set)
 
 Expects to pick up K8s credentials from the environment

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ driver:
       cnameTarget: custom-loadbalancer.example.com
       certManagerIssuer: lets-encrypt
       ingressClass: custom-nginx
+    storage:
+      enabled: true
+      storageClass: nfs-storage
+      size: 5Gi
 ```
 
 - `registry` is the Docker Registry to load Stack Containers from
@@ -44,6 +48,9 @@ AWS EKS specific annotation for ALB Ingress. or `openshift` to allow running on 
 - `customHostname.cnameTarget` The hostname users should configure their DNS entries to point at. Required. (default not set)
 - `customHostname.certManagerIssuer` Name of the Cluster issuer to use to create HTTPS certs for the custom hostname (default not set)
 - `customHostname.ingressClass` Name of the IngressClass to use to expose the custom hostname (default not set)
+- `storage.enabled` Mounts a persistent volume on `/data/storage` (default false)
+- `storage.storageClass` Name of StorageClass to use to allocate the volume (default not set)
+- `storage.size` Size of the volume to request (default not set)
 
 Expects to pick up K8s credentials from the environment
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -476,7 +476,7 @@ const createProject = async (project, options) => {
         const localPVC = await createPersistentVolumeClaim(project, options)
         console.log(localPVC)
         try {
-            //await this._k8sApi.createNamespacedPersistentVolumeClaim(namespace, localPVC)
+            await this._k8sApi.createNamespacedPersistentVolumeClaim(namespace, localPVC)
         } catch (err) {
             if (err.statusCode === 409) {
                 this._app.log.warn(`[k8s] PVC for instance ${project.id} already exists, proceeding...`)
@@ -909,7 +909,7 @@ module.exports = {
         // not sure about this, I think it needs to be after deleting the deployment
         if (this._app.config.driver.options?.storage?.enabled) {
             try {
-                this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
+                await this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
             } catch (err) {
                 this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()}`)
             }
@@ -1000,7 +1000,7 @@ module.exports = {
         }
         if (this._app.config.driver.options?.storage?.enabled) {
             try {
-                this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
+                await this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
             } catch (err) {
                 this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()}`)
             }

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -308,7 +308,7 @@ const createPersistentVolumeClaim = async (project, options) => {
     if (drvOptions?.storage?.storageClass) {
         pvc.spec.storageClassName = drvOptions.storage.storageClass
     } else if (drvOptions?.storage?.storageClassEFSTag) {
-        pvc.spec.storageClassName = awsEFS.lookupStorageClass(drvOptions?.storage?.storageClassEFSTag)
+        pvc.spec.storageClassName = await awsEFS.lookupStorageClass(drvOptions?.storage?.storageClassEFSTag)
     }
 
     if (drvOptions?.storage?.size) {
@@ -321,6 +321,7 @@ const createPersistentVolumeClaim = async (project, options) => {
         'ff-project-id': project.id,
         'ff-project-name': project.safeName
     }
+    console.log(`PVC: ${JSON.stringify(pvc,null,2)}`)
     return pvc
 }
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -317,10 +317,10 @@ const createDeployment = async (project, options) => {
         } else {
             localPod.spec.containers[0].volumeMounts = [volMount]
         }
-        if (Array.isArray(localPod.spec.containers[0]).volumes) {
-            localPod.spec.containers[0].volumes.push(vol)
+        if (Array.isArray(localPod.spec.volumes)) {
+            localPod.spec.volumes.push(vol)
         } else {
-            localPod.spec.containers[0].volumes = [vol]
+            localPod.spec.volumes = [vol]
         }
     }
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -459,7 +459,9 @@ const createPersistentVolumeClaim = async (project, options) => {
 
     pvc.metadata.namespace = namespace
     pvc.metadata.name = `${project.safeName}-pvc`
-    pvc.metadata.labels.name = project.safeName
+    pvc.metadata.labels = {
+        name: project.safeName
+    }
 }
 
 const createProject = async (project, options) => {

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -1,6 +1,7 @@
 const got = require('got')
 const k8s = require('@kubernetes/client-node')
 const _ = require('lodash')
+const awsEFS = require('./lib/aws-efs.js')
 
 const {
     deploymentTemplate,
@@ -306,6 +307,8 @@ const createPersistentVolumeClaim = async (project, options) => {
 
     if (drvOptions?.storage?.storageClass) {
         pvc.spec.storageClassName = drvOptions.storage.storageClass
+    } else if (drvOptions?.storage?.storageClassEFSTag) {
+        pvc.spec.storageClassName = awsEFS.lookupStorageClass(drvOptions?.storage?.storageClassEFSTag)
     }
 
     if (drvOptions?.storage?.size) {

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -165,7 +165,7 @@ const createDeployment = async (project, options) => {
         const vol = {
             name: 'persistence',
             persistentVolumeClaim: {
-                claimName: `${project.safeName}-pvc`
+                claimName: `${project.id}-pvc`
             }
         }
         if (Array.isArray(localPod.spec.containers[0].volumeMounts)) {

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -902,6 +902,15 @@ module.exports = {
             await this._k8sApi.deleteNamespacedPod(project.safeName, this._namespace)
         }
 
+        //not sure about this, I think it needs to be after deleting the deployment
+        if (this._app.config.driver.options?.storage?.enabled) {
+            try {
+                this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
+            } catch (err) {
+                this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()}`)
+            }
+        }
+
         this._projects[project.id].state = 'suspended'
         return new Promise((resolve, reject) => {
             let counter = 0
@@ -983,6 +992,13 @@ module.exports = {
                 } else {
                     this._app.log.error(`[k8s] Instance ${project.id} - error deleting pod: ${err.toString()}`)
                 }
+            }
+        }
+        if (this._app.config.driver.options?.storage?.enabled) {
+            try {
+                this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
+            } catch (err) {
+                this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()}`)
             }
         }
         delete this._projects[project.id]

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -474,7 +474,7 @@ const createProject = async (project, options) => {
 
     if (this._app.config.driver.options?.storage?.enabled) {
         const localPVC = await createPersistentVolumeClaim(project, options)
-        console.log(localPVC)
+        console.log(JSON.stringify(localPVC, null, 2))
         try {
             await this._k8sApi.createNamespacedPersistentVolumeClaim(namespace, localPVC)
         } catch (err) {
@@ -482,7 +482,8 @@ const createProject = async (project, options) => {
                 this._app.log.warn(`[k8s] PVC for instance ${project.id} already exists, proceeding...`)
             } else {
                 if (project.state !== 'suspended') {
-                    this._app.log.error(`[k8s] Instance ${project.id} - error creating PVC: ${err.toString()}`)
+                    this._app.log.error(`[k8s] Instance ${project.id} - error creating PVC: ${err.toString()} ${err.statusCode}`)
+                    console.log(err)
                     throw err
                 }
             }

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -329,7 +329,7 @@ const createProject = async (project, options) => {
 
     if (this._app.config.driver.options?.storage?.enabled) {
         const localPVC = await createPersistentVolumeClaim(project, options)
-        //console.log(JSON.stringify(localPVC, null, 2))
+        // console.log(JSON.stringify(localPVC, null, 2))
         try {
             await this._k8sApi.createNamespacedPersistentVolumeClaim(namespace, localPVC)
         } catch (err) {
@@ -859,7 +859,7 @@ module.exports = {
                 await this._k8sApi.deleteNamespacedPersistentVolumeClaim(`${project.safeName}-pvc`, this._namespace)
             } catch (err) {
                 this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()} ${err.statusCode}`)
-                console.log(err)
+                // console.log(err)
             }
         }
         delete this._projects[project.id]

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -321,7 +321,7 @@ const createPersistentVolumeClaim = async (project, options) => {
         'ff-project-id': project.id,
         'ff-project-name': project.safeName
     }
-    console.log(`PVC: ${JSON.stringify(pvc,null,2)}`)
+    console.log(`PVC: ${JSON.stringify(pvc, null, 2)}`)
     return pvc
 }
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -907,14 +907,14 @@ module.exports = {
             await this._k8sApi.deleteNamespacedPod(project.safeName, this._namespace)
         }
 
-        // not sure about this, I think it needs to be after deleting the deployment
-        if (this._app.config.driver.options?.storage?.enabled) {
-            try {
-                await this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
-            } catch (err) {
-                this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()} ${err.statusCode}`)
-            }
-        }
+        // We should not delete the PVC when the instance is suspended
+        // if (this._app.config.driver.options?.storage?.enabled) {
+        //     try {
+        //         await this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
+        //     } catch (err) {
+        //         this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()} ${err.statusCode}`)
+        //     }
+        // }
 
         this._projects[project.id].state = 'suspended'
         return new Promise((resolve, reject) => {
@@ -1003,7 +1003,7 @@ module.exports = {
             try {
                 await this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
             } catch (err) {
-                this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()}`)
+                this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()} ${err.statusCode}`)
             }
         }
         delete this._projects[project.id]

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -462,6 +462,7 @@ const createPersistentVolumeClaim = async (project, options) => {
     pvc.metadata.labels = {
         name: project.safeName
     }
+    return pvc
 }
 
 const createProject = async (project, options) => {
@@ -473,8 +474,9 @@ const createProject = async (project, options) => {
 
     if (this._app.config.driver.options?.storage?.enabled) {
         const localPVC = await createPersistentVolumeClaim(project, options)
+        console.log(localPVC)
         try {
-            await this._k8sApi.createNamespacedPersistentVolumeClaim(namespace, localPVC)
+            //await this._k8sApi.createNamespacedPersistentVolumeClaim(namespace, localPVC)
         } catch (err) {
             if (err.statusCode === 409) {
                 this._app.log.warn(`[k8s] PVC for instance ${project.id} already exists, proceeding...`)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -902,7 +902,7 @@ module.exports = {
             await this._k8sApi.deleteNamespacedPod(project.safeName, this._namespace)
         }
 
-        //not sure about this, I think it needs to be after deleting the deployment
+        // not sure about this, I think it needs to be after deleting the deployment
         if (this._app.config.driver.options?.storage?.enabled) {
             try {
                 this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -313,9 +313,10 @@ const createPersistentVolumeClaim = async (project, options) => {
     }
 
     pvc.metadata.namespace = namespace
-    pvc.metadata.name = `${project.safeName}-pvc`
+    pvc.metadata.name = `${project.id}-pvc`
     pvc.metadata.labels = {
-        name: project.safeName
+        'ff-project-id': project.id,
+        'ff-project-name': project.safeName
     }
     return pvc
 }
@@ -856,7 +857,7 @@ module.exports = {
         }
         if (this._app.config.driver.options?.storage?.enabled) {
             try {
-                await this._k8sApi.deleteNamespacedPersistentVolumeClaim(`${project.safeName}-pvc`, this._namespace)
+                await this._k8sApi.deleteNamespacedPersistentVolumeClaim(`${project.id}-pvc`, this._namespace)
             } catch (err) {
                 this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()} ${err.statusCode}`)
                 // console.log(err)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -22,153 +22,6 @@ const {
  *
  */
 
-// const deploymentTemplate = {
-//     apiVersion: 'apps/v1',
-//     kind: 'Deployment',
-//     metadata: {
-//         // name: "k8s-client-test-deployment",
-//         labels: {
-//             // name: "k8s-client-test-deployment",
-//             nodered: 'true'
-//             // app: "k8s-client-test-deployment"
-//         }
-//     },
-//     spec: {
-//         replicas: 1,
-//         selector: {
-//             matchLabels: {
-//                 // app: "k8s-client-test-deployment"
-//             }
-//         },
-//         template: {
-//             metadata: {
-//                 labels: {
-//                     // name: "k8s-client-test-deployment",
-//                     nodered: 'true'
-//                     // app: "k8s-client-test-deployment"
-//                 }
-//             },
-//             spec: {
-//                 securityContext: {
-//                     runAsUser: 1000,
-//                     runAsGroup: 1000,
-//                     fsGroup: 1000
-//                 },
-//                 containers: [
-//                     {
-//                         resources: {
-//                             requests: {
-//                                 // 10th of a core
-//                                 cpu: '100m',
-//                                 memory: '128Mi'
-//                             },
-//                             limits: {
-//                                 cpu: '125m',
-//                                 memory: '192Mi'
-//                             }
-//                         },
-//                         name: 'node-red',
-//                         // image: "docker-pi.local:5000/bronze-node-red",
-//                         imagePullPolicy: 'Always',
-//                         env: [
-//                             // {name: "APP_NAME", value: "test"},
-//                             { name: 'TZ', value: 'Europe/London' }
-//                         ],
-//                         ports: [
-//                             { name: 'web', containerPort: 1880, protocol: 'TCP' },
-//                             { name: 'management', containerPort: 2880, protocol: 'TCP' }
-//                         ],
-//                         securityContext: {
-//                             allowPrivilegeEscalation: false
-//                         }
-//                     }
-//                 ]
-//             },
-//             enableServiceLinks: false
-//         }
-//     }
-// }
-
-// const serviceTemplate = {
-//     apiVersion: 'v1',
-//     kind: 'Service',
-//     metadata: {
-//         // name: "k8s-client-test-service"
-//     },
-//     spec: {
-//         type: 'ClusterIP',
-//         selector: {
-//             // name: "k8s-client-test"
-//         },
-//         ports: [
-//             { name: 'web', port: 1880, protocol: 'TCP' },
-//             { name: 'management', port: 2880, protocol: 'TCP' }
-//         ]
-//     }
-// }
-
-// const ingressTemplate = {
-//     apiVersion: 'networking.k8s.io/v1',
-//     kind: 'Ingress',
-//     metadata: {
-//         // name: "k8s-client-test-ingress",
-//         // namespace: 'flowforge',
-//         annotations: process.env.INGRESS_ANNOTATIONS ? JSON.parse(process.env.INGRESS_ANNOTATIONS) : {}
-//     },
-//     spec: {
-//         ingressClassName: process.env.INGRESS_CLASS_NAME ? process.env.INGRESS_CLASS_NAME : null,
-//         rules: [
-//             {
-//                 // host: "k8s-client-test" + "." + "ubuntu.local",
-//                 http: {
-//                     paths: [
-//                         {
-//                             pathType: 'Prefix',
-//                             path: '/',
-//                             backend: {
-//                                 service: {
-//                                     // name: 'k8s-client-test-service',
-//                                     port: { number: 1880 }
-//                                 }
-//                             }
-//                         }
-//                     ]
-//                 }
-//             }
-//         ]
-//     }
-// }
-
-// const customIngressTemplate = {
-//     apiVersion: 'networking.k8s.io/v1',
-//     kind: 'Ingress',
-//     metadata: {
-//         annotations: {}
-//     },
-//     spec: {
-//         rules: [
-//             {
-//                 http: {
-//                     paths: [
-//                         {
-//                             pathType: 'Prefix',
-//                             path: '/',
-//                             backend: {
-//                                 service: {
-//                                     port: { number: 1880 }
-//                                 }
-//                             }
-//                         }
-//                     ]
-//                 }
-//             }
-//         ],
-//         tls: [
-
-//         ]
-//     }
-// }
-
 const createDeployment = async (project, options) => {
     const stack = project.ProjectStack.properties
 
@@ -912,7 +765,7 @@ module.exports = {
         // We should not delete the PVC when the instance is suspended
         // if (this._app.config.driver.options?.storage?.enabled) {
         //     try {
-        //         await this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
+        //         await this._k8sApi.deleteNamespacedPersistentVolumeClaim(`${project.safeName}-pvc`, this._namespace)
         //     } catch (err) {
         //         this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()} ${err.statusCode}`)
         //     }
@@ -1003,7 +856,7 @@ module.exports = {
         }
         if (this._app.config.driver.options?.storage?.enabled) {
             try {
-                await this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
+                await this._k8sApi.deleteNamespacedPersistentVolumeClaim(`${project.safeName}-pvc`, this._namespace)
             } catch (err) {
                 this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()} ${err.statusCode}`)
                 console.log(err)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -310,7 +310,9 @@ const createDeployment = async (project, options) => {
         }
         const vol = {
             name: 'persistence',
-            persistentVolumeClaim: `${project.safeName}-pvc`
+            persistentVolumeClaim: {
+                claimName: `${project.safeName}-pvc`
+            }
         }
         if (Array.isArray(localPod.spec.containers[0].volumeMounts)) {
             localPod.spec.containers[0].volumeMounts.push(volMount)

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -485,7 +485,7 @@ const createProject = async (project, options) => {
             } else {
                 if (project.state !== 'suspended') {
                     this._app.log.error(`[k8s] Instance ${project.id} - error creating PVC: ${err.toString()} ${err.statusCode}`)
-                    console.log(err)
+                    // console.log(err)
                     throw err
                 }
             }
@@ -1006,6 +1006,7 @@ module.exports = {
                 await this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
             } catch (err) {
                 this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()} ${err.statusCode}`)
+                console.log(err)
             }
         }
         delete this._projects[project.id]

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -303,7 +303,7 @@ const createDeployment = async (project, options) => {
         localPod.spec.containers[0].env.push({ name: 'NODE_EXTRA_CA_CERTS', value: '/usr/local/ssl-certs/chain.pem' })
     }
 
-    if (this._app.config.driver.options?.storge?.enabled) {
+    if (this._app.config.driver.options?.storage?.enabled) {
         const volMount = {
             name: 'persistence',
             mountPath: '/data/storage'
@@ -474,7 +474,7 @@ const createProject = async (project, options) => {
 
     if (this._app.config.driver.options?.storage?.enabled) {
         const localPVC = await createPersistentVolumeClaim(project, options)
-        console.log(JSON.stringify(localPVC, null, 2))
+        //console.log(JSON.stringify(localPVC, null, 2))
         try {
             await this._k8sApi.createNamespacedPersistentVolumeClaim(namespace, localPVC)
         } catch (err) {
@@ -912,7 +912,7 @@ module.exports = {
             try {
                 await this._k8sApi.deleteCollectionNamespacedPersistentVolumeClaim(this._namespace, `${project.safeName}-pvc`)
             } catch (err) {
-                this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()}`)
+                this._app.log.error(`[k8s] Instance ${project.id} - error deleting PVC: ${err.toString()} ${err.statusCode}`)
             }
         }
 

--- a/lib/aws-efs.js
+++ b/lib/aws-efs.js
@@ -1,9 +1,12 @@
 const { EFSClient, DescribeFileSystemsCommand, DescribeAccessPointsCommand } = require("@aws-sdk/client-efs")
 
-const config = {}
-const client = new EFSClient(config)
+let client
 
 async function lookupStorageClass (tag) {
+
+    if (!client) {
+        const client = new EFSClient()
+    }
 
     const fsCommand = new DescribeFileSystemsCommand()
     const fsList = await client.send(fsCommand)

--- a/lib/aws-efs.js
+++ b/lib/aws-efs.js
@@ -1,0 +1,46 @@
+const { EFSClient, DescribeFileSystemsCommand, DescribeAccessPointsCommand } = require("@aws-sdk/client-efs")
+
+const client = new EFSClient(config)
+
+async function lookupStorageClass (tag) {
+
+    const fsCommand = new DescribeFileSystemsCommand()
+    const fsList = await client.send(fsCommand)
+    console.log(fsList)
+
+    for (let i = 0; i< fsList.FileSystems.length; i++) {
+        let found = false
+        let storageClass = ''
+        fsList.FileSystems[i].Tags.forEach(tag => {
+            if (tag.Key === tag) {
+                found = true
+            } 
+            if (tag.Key === 'storage-class-name') {
+                storageClass = tag.Value
+            }
+        })
+        if (found) {
+            const apParams = {
+                FileSystemId: fsList.FileSystems[i].FileSystemId
+            }
+            // console.log(apParams)
+            const apListCommand = new DescribeAccessPointsCommand(apParams)
+            const apList = await client.send(apListCommand)
+            fileSystems[fsList.FileSystems[i].FileSystemId] = {
+                apCount: apList.AccessPoints.length,
+                storageClass
+            }
+        }
+        
+    }
+    fileSystems.sort((a,b) => a.apCount - b.apCount)
+
+    return fileSystems[0].storageClass
+
+    // console.log(JSON.stringify(fileSystems, null, 2))
+}
+
+
+module.exports = {
+    lookupStorageClass
+}

--- a/lib/aws-efs.js
+++ b/lib/aws-efs.js
@@ -4,7 +4,7 @@ let client
 
 async function lookupStorageClass (tagName) {
 
-    console.log(`Looking for ${tagName}`)
+    // console.log(`Looking for ${tagName}`)
 
     if (!client) {
         client = new EFSClient()
@@ -12,7 +12,7 @@ async function lookupStorageClass (tagName) {
 
     const fsCommand = new DescribeFileSystemsCommand()
     const fsList = await client.send(fsCommand)
-    console.log(JSON.stringify(fsList, null, 2))
+    // console.log(JSON.stringify(fsList, null, 2))
 
     const fileSystems = []
 

--- a/lib/aws-efs.js
+++ b/lib/aws-efs.js
@@ -19,7 +19,6 @@ async function lookupStorageClass (tagName) {
     for (let i = 0; i<fsList.FileSystems.length; i++) {
         let found = false
         let storageClass = ''
-        // fsList.FileSystems[i].Tags.forEach(tag => {
         for (let j = 0; j<fsList.FileSystems[i].Tags.length; j++) {
             const tag = fsList.FileSystems[i].Tags[j]
             if (tag.Key === tagName) {
@@ -30,7 +29,7 @@ async function lookupStorageClass (tagName) {
             }
         }
         if (found) {
-            console.log(storageClass)
+            // console.log(storageClass)
             const apParams = {
                 FileSystemId: fsList.FileSystems[i].FileSystemId
             }
@@ -42,16 +41,11 @@ async function lookupStorageClass (tagName) {
                 apCount: apList.AccessPoints.length,
                 storageClass
             })
-        } else {
-            console.log(`${fsList.FileSystems[i]} efs not tagged`)
-        }
-        
+        } 
     }
     fileSystems.sort((a,b) => a.apCount - b.apCount)
 
-    return fileSystems[0].storageClass
-
-    // console.log(JSON.stringify(fileSystems, null, 2))
+    return fileSystems[0]?.storageClass
 }
 
 

--- a/lib/aws-efs.js
+++ b/lib/aws-efs.js
@@ -12,6 +12,8 @@ async function lookupStorageClass (tag) {
     const fsList = await client.send(fsCommand)
     console.log(fsList)
 
+    const fileSystems = []
+
     for (let i = 0; i< fsList.FileSystems.length; i++) {
         let found = false
         let storageClass = ''
@@ -30,10 +32,11 @@ async function lookupStorageClass (tag) {
             // console.log(apParams)
             const apListCommand = new DescribeAccessPointsCommand(apParams)
             const apList = await client.send(apListCommand)
-            fileSystems[fsList.FileSystems[i].FileSystemId] = {
+            // fileSystems[fsList.FileSystems[i].FileSystemId] 
+            fileSystems.push({
                 apCount: apList.AccessPoints.length,
                 storageClass
-            }
+            })
         }
         
     }

--- a/lib/aws-efs.js
+++ b/lib/aws-efs.js
@@ -5,7 +5,7 @@ let client
 async function lookupStorageClass (tag) {
 
     if (!client) {
-        const client = new EFSClient()
+        client = new EFSClient()
     }
 
     const fsCommand = new DescribeFileSystemsCommand()

--- a/lib/aws-efs.js
+++ b/lib/aws-efs.js
@@ -1,5 +1,6 @@
 const { EFSClient, DescribeFileSystemsCommand, DescribeAccessPointsCommand } = require("@aws-sdk/client-efs")
 
+const config = {}
 const client = new EFSClient(config)
 
 async function lookupStorageClass (tag) {

--- a/lib/aws-efs.js
+++ b/lib/aws-efs.js
@@ -10,22 +10,25 @@ async function lookupStorageClass (tag) {
 
     const fsCommand = new DescribeFileSystemsCommand()
     const fsList = await client.send(fsCommand)
-    console.log(fsList)
+    console.log(JSON.stringify(fsList, null, 2))
 
     const fileSystems = []
 
-    for (let i = 0; i< fsList.FileSystems.length; i++) {
+    for (let i = 0; i<fsList.FileSystems.length; i++) {
         let found = false
         let storageClass = ''
-        fsList.FileSystems[i].Tags.forEach(tag => {
+        // fsList.FileSystems[i].Tags.forEach(tag => {
+        for (let j = 0; j<fsList.FileSystems[i].Tags.length; j++) {
+            const tag = fsList.FileSystems[i].Tags[j]
             if (tag.Key === tag) {
                 found = true
             } 
             if (tag.Key === 'storage-class-name') {
                 storageClass = tag.Value
             }
-        })
+        }
         if (found) {
+            console.log(storageClass)
             const apParams = {
                 FileSystemId: fsList.FileSystems[i].FileSystemId
             }
@@ -37,6 +40,8 @@ async function lookupStorageClass (tag) {
                 apCount: apList.AccessPoints.length,
                 storageClass
             })
+        } else {
+            console.log(`${fsList.FileSystems[i]} efs not tagged`)
         }
         
     }

--- a/lib/aws-efs.js
+++ b/lib/aws-efs.js
@@ -2,7 +2,9 @@ const { EFSClient, DescribeFileSystemsCommand, DescribeAccessPointsCommand } = r
 
 let client
 
-async function lookupStorageClass (tag) {
+async function lookupStorageClass (tagName) {
+
+    console.log(`Looking for ${tagName}`)
 
     if (!client) {
         client = new EFSClient()
@@ -20,7 +22,7 @@ async function lookupStorageClass (tag) {
         // fsList.FileSystems[i].Tags.forEach(tag => {
         for (let j = 0; j<fsList.FileSystems[i].Tags.length; j++) {
             const tag = fsList.FileSystems[i].Tags[j]
-            if (tag.Key === tag) {
+            if (tag.Key === tagName) {
                 found = true
             } 
             if (tag.Key === 'storage-class-name') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "2.5.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@aws-sdk/client-efs": "^3.600.0",
                 "@kubernetes/client-node": "^0.18.1",
                 "got": "^11.8.0",
                 "lodash": "^4.17.21"
@@ -16,6 +17,638 @@
             "devDependencies": {
                 "eslint": "^8.25.0",
                 "eslint-config-standard": "^17.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-efs": {
+            "version": "3.600.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-efs/-/client-efs-3.600.0.tgz",
+            "integrity": "sha512-FM+E81BY/QSwH7hWJQymQXUgvbHlLOroa1IBWzWci6FswaLO64wZu1B9BRwRYp2grH1JA/TqbQ6GTXdfPIAAog==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.600.0",
+                "@aws-sdk/client-sts": "3.600.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.600.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-efs/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.598.0.tgz",
+            "integrity": "sha512-nOI5lqPYa+YZlrrzwAJywJSw3MKVjvu6Ge2fCqQUNYMfxFB0NAaDFnl0EPjXi+sEbtCuz/uWE77poHbqiZ+7Iw==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.600.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.600.0.tgz",
+            "integrity": "sha512-7+I8RWURGfzvChyNQSyj5/tKrqRbzRl7H+BnTOf/4Vsw1nFOi5ROhlhD4X/Y0QCTacxnaoNcIrqnY7uGGvVRzw==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sts": "3.600.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.600.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts": {
+            "version": "3.600.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.600.0.tgz",
+            "integrity": "sha512-KQG97B7LvTtTiGmjlrG1LRAY8wUvCQzrmZVV5bjrJ/1oXAU7DITYwVbSJeX9NWg6hDuSk0VE3MFwIXS2SvfLIA==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.600.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.600.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.598.0.tgz",
+            "integrity": "sha512-HaSjt7puO5Cc7cOlrXFCW0rtA0BM9lvzjl56x0A20Pt+0wxXGeTOZZOkXQIepbrFkV2e/HYukuT9e99vXDm59g==",
+            "dependencies": {
+                "@smithy/core": "^2.2.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/signature-v4": "^3.1.0",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.598.0.tgz",
+            "integrity": "sha512-vi1khgn7yXzLCcgSIzQrrtd2ilUM0dWodxj3PQ6BLfP0O+q1imO3hG1nq7DVyJtq7rFHs6+9N8G4mYvTkxby2w==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.598.0.tgz",
+            "integrity": "sha512-N7cIafi4HVlQvEgvZSo1G4T9qb/JMLGMdBsDCT5XkeJrF0aptQWzTFH0jIdZcLrMYvzPcuEyO3yCBe6cy/ba0g==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-stream": "^3.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.598.0.tgz",
+            "integrity": "sha512-/ppcIVUbRwDIwJDoYfp90X3+AuJo2mvE52Y1t2VSrvUovYn6N4v95/vXj6LS8CNDhz2jvEJYmu+0cTMHdhI6eA==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.598.0",
+                "@aws-sdk/credential-provider-http": "3.598.0",
+                "@aws-sdk/credential-provider-process": "3.598.0",
+                "@aws-sdk/credential-provider-sso": "3.598.0",
+                "@aws-sdk/credential-provider-web-identity": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/credential-provider-imds": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.598.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.600.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.600.0.tgz",
+            "integrity": "sha512-1pC7MPMYD45J7yFjA90SxpR0yaSvy+yZiq23aXhAPZLYgJBAxHLu0s0mDCk/piWGPh8+UGur5K0bVdx4B1D5hw==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.598.0",
+                "@aws-sdk/credential-provider-http": "3.598.0",
+                "@aws-sdk/credential-provider-ini": "3.598.0",
+                "@aws-sdk/credential-provider-process": "3.598.0",
+                "@aws-sdk/credential-provider-sso": "3.598.0",
+                "@aws-sdk/credential-provider-web-identity": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/credential-provider-imds": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.598.0.tgz",
+            "integrity": "sha512-rM707XbLW8huMk722AgjVyxu2tMZee++fNA8TJVNgs1Ma02Wx6bBrfIvlyK0rCcIRb0WdQYP6fe3Xhiu4e8IBA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.598.0.tgz",
+            "integrity": "sha512-5InwUmrAuqQdOOgxTccRayMMkSmekdLk6s+az9tmikq0QFAHUCtofI+/fllMXSR9iL6JbGYi1940+EUmS4pHJA==",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.598.0",
+                "@aws-sdk/token-providers": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.598.0.tgz",
+            "integrity": "sha512-GV5GdiMbz5Tz9JO4NJtRoFXjW0GPEujA0j+5J/B723rTN+REHthJu48HdBKouHGhdzkDWkkh1bu52V02Wprw8w==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.598.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.598.0.tgz",
+            "integrity": "sha512-WiaG059YBQwQraNejLIi0gMNkX7dfPZ8hDIhvMr5aVPRbaHH8AYF3iNSsXYCHvA2Cfa1O9haYXsuMF9flXnCmA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.598.0.tgz",
+            "integrity": "sha512-bxBjf/VYiu3zfu8SYM2S9dQQc3tz5uBAOcPz/Bt8DyyK3GgOpjhschH/2XuUErsoUO1gDJqZSdGOmuHGZQn00Q==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.598.0.tgz",
+            "integrity": "sha512-vjT9BeFY9FeN0f8hm2l6F53tI0N5bUq6RcDkQXKNabXBnQxKptJRad6oP2X5y3FoVfBLOuDkQgiC2940GIPxtQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.598.0.tgz",
+            "integrity": "sha512-4tjESlHG5B5MdjUaLK7tQs/miUtHbb6deauQx8ryqSBYOhfHVgb1ZnzvQR0bTrhpqUg0WlybSkDaZAICf9xctg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.598.0.tgz",
+            "integrity": "sha512-oYXhmTokSav4ytmWleCr3rs/1nyvZW/S0tdi6X7u+dLNL5Jee+uMxWGzgOrWK6wrQOzucLVjS4E/wA11Kv2GTw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.598.0.tgz",
+            "integrity": "sha512-TKY1EVdHVBnZqpyxyTHdpZpa1tUpb6nxVeRNn1zWG8QB5MvH4ALLd/jR+gtmWDNQbIG4cVuBOZFVL8hIYicKTA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sso-oidc": "^3.598.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+            "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
+            "dependencies": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.598.0.tgz",
+            "integrity": "sha512-Qo9UoiVVZxcOEdiOMZg3xb1mzkTxrhd4qSlg5QQrfWPJVx/QOg+Iy0NtGxPtHtVZNHZxohYwDwV/tfsnDSE2gQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-endpoints": "^2.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+            "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.598.0.tgz",
+            "integrity": "sha512-36Sxo6F+ykElaL1mWzWjlg+1epMpSe8obwhCN1yGE7Js9ywy5U6k6l+A3q3YM9YRbm740sNxncbwLklMvuhTKw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.598.0.tgz",
+            "integrity": "sha512-oyWGcOlfTdzkC6SVplyr0AGh54IMrDxbhg5RxJ5P+V4BKfcDoDcZV9xenUk9NsOi9MuUjxMumb9UJGkDhM1m0A==",
+            "dependencies": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -177,6 +810,529 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@smithy/abort-controller": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+            "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.4.tgz",
+            "integrity": "sha512-VwiOk7TwXoE7NlNguV/aPq1hFH72tqkHCw8eWXbr2xHspRyyv9DLpLXhq+Ieje+NwoqXrY0xyQjPXdOE6cGcHA==",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/core": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.4.tgz",
+            "integrity": "sha512-qdY3LpMOUyLM/gfjjMQZui+UTNS7kBRDWlvyIhVOql5dn2J3isk9qUTBtQ1CbDH8MTugHis1zu3h4rH+Qmmh4g==",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.0.4",
+                "@smithy/middleware-retry": "^3.0.7",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/smithy-client": "^3.1.5",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.3.tgz",
+            "integrity": "sha512-U1Yrv6hx/mRK6k8AncuI6jLUx9rn0VVSd9NPEX6pyYFBfkSkChOc/n4zUb8alHUVg83TbI4OdZVo1X0Zfj3ijA==",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.0.tgz",
+            "integrity": "sha512-vFvDxMrc6sO5Atec8PaISckMcAwsCrRhYxwUylg97bRT2KZoumOF7qk5+6EVUtuM1IG9AJV5aqXnHln9ZdXHpg==",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+            "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+            "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+            "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.3.tgz",
+            "integrity": "sha512-Dbz2bzexReYIQDWMr+gZhpwBetNXzbhnEMhYKA6urqmojO14CsXjnsoPYO8UL/xxcawn8ZsuVU61ElkLSltIUQ==",
+            "dependencies": {
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.4.tgz",
+            "integrity": "sha512-whUJMEPwl3ANIbXjBXZVdJNgfV2ZU8ayln7xUM47rXL2txuenI7jQ/VFFwCzy5lCmXScjp6zYtptW5Evud8e9g==",
+            "dependencies": {
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.7.tgz",
+            "integrity": "sha512-f5q7Y09G+2h5ivkSx5CHvlAT4qRR3jBFEsfXyQ9nFNiWQlr8c48blnu5cmbTQ+p1xmIO14UXzKoF8d7Tm0Gsjw==",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/smithy-client": "^3.1.5",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+            "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+            "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.3.tgz",
+            "integrity": "sha512-rxdpAZczzholz6CYZxtqDu/aKTxATD5DAUDVj7HoEulq+pDSQVWzbg0btZDlxeFfa6bb2b5tUvgdX5+k8jUqcg==",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.1.tgz",
+            "integrity": "sha512-L71NLyPeP450r2J/mfu1jMc//Z1YnqJt2eSNw7uhiItaONnBLDA68J5jgxq8+MBDsYnFwNAIc7dBG1ImiWBiwg==",
+            "dependencies": {
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+            "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.3.tgz",
+            "integrity": "sha512-x5jmrCWwQlx+Zv4jAtc33ijJ+vqqYN+c/ZkrnpvEe/uDas7AT7A/4Rc2CdfxgWv4WFGmEqODIrrUToPN6DDkGw==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+            "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+            "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+            "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.3.tgz",
+            "integrity": "sha512-Z8Y3+08vgoDgl4HENqNnnzSISAaGrF2RoKupoC47u2wiMp+Z8P/8mDh1CL8+8ujfi2U5naNvopSBmP/BUj8b5w==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
+            "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.5.tgz",
+            "integrity": "sha512-x9bL9Mx2CT2P1OiUlHM+ZNpbVU6TgT32f9CmTRzqIHA7M4vYrROCWEoC3o4xHNJASoGd4Opos3cXYPgh+/m4Ww==",
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.0.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+            "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+            "dependencies": {
+                "@smithy/querystring-parser": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+            "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+            "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+            "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+            "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.7.tgz",
+            "integrity": "sha512-Q2txLyvQyGfmjsaDbVV7Sg8psefpFcrnlGapDzXGFRPFKRBeEg6OvFK8FljqjeHSaCZ6/UuzQExUPqBR/2qlDA==",
+            "dependencies": {
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.1.5",
+                "@smithy/types": "^3.3.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.7.tgz",
+            "integrity": "sha512-F4Qcj1fG6MGi2BSWCslfsMSwllws/WzYONBGtLybyY+halAcXdWhcew+mej8M5SKd5hqPYp4f7b+ABQEaeytgg==",
+            "dependencies": {
+                "@smithy/config-resolver": "^3.0.4",
+                "@smithy/credential-provider-imds": "^3.1.3",
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.1.5",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.4.tgz",
+            "integrity": "sha512-ZAtNf+vXAsgzgRutDDiklU09ZzZiiV/nATyqde4Um4priTmasDH+eLpp3tspL0hS2dEootyFMhu1Y6Y+tzpWBQ==",
+            "dependencies": {
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+            "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+            "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+            "dependencies": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+            "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+            "dependencies": {
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.5.tgz",
+            "integrity": "sha512-xC3L5PKMAT/Bh8fmHNXP9sdQ4+4aKVUU3EEJ2CF/lLk7R+wtMJM+v/1B4en7jO++Wa5spGzFDBCl0QxgbUc5Ug==",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^3.2.0",
+                "@smithy/node-http-handler": "^3.1.1",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@szmarczak/http-timer": {
@@ -464,6 +1620,11 @@
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
+        },
+        "node_modules/bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -1266,6 +2427,27 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+            "funding": [
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
         },
         "node_modules/fastq": {
             "version": "1.15.0",
@@ -2914,6 +4096,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3014,9 +4201,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-            "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
@@ -3230,6 +4417,533 @@
         }
     },
     "dependencies": {
+        "@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "requires": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-utf8": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                    "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "requires": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "requires": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-utf8": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                    "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                }
+            }
+        },
+        "@aws-sdk/client-efs": {
+            "version": "3.600.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-efs/-/client-efs-3.600.0.tgz",
+            "integrity": "sha512-FM+E81BY/QSwH7hWJQymQXUgvbHlLOroa1IBWzWci6FswaLO64wZu1B9BRwRYp2grH1JA/TqbQ6GTXdfPIAAog==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.600.0",
+                "@aws-sdk/client-sts": "3.600.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.600.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+                }
+            }
+        },
+        "@aws-sdk/client-sso": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.598.0.tgz",
+            "integrity": "sha512-nOI5lqPYa+YZlrrzwAJywJSw3MKVjvu6Ge2fCqQUNYMfxFB0NAaDFnl0EPjXi+sEbtCuz/uWE77poHbqiZ+7Iw==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/client-sso-oidc": {
+            "version": "3.600.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.600.0.tgz",
+            "integrity": "sha512-7+I8RWURGfzvChyNQSyj5/tKrqRbzRl7H+BnTOf/4Vsw1nFOi5ROhlhD4X/Y0QCTacxnaoNcIrqnY7uGGvVRzw==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sts": "3.600.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.600.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/client-sts": {
+            "version": "3.600.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.600.0.tgz",
+            "integrity": "sha512-KQG97B7LvTtTiGmjlrG1LRAY8wUvCQzrmZVV5bjrJ/1oXAU7DITYwVbSJeX9NWg6hDuSk0VE3MFwIXS2SvfLIA==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.600.0",
+                "@aws-sdk/core": "3.598.0",
+                "@aws-sdk/credential-provider-node": "3.600.0",
+                "@aws-sdk/middleware-host-header": "3.598.0",
+                "@aws-sdk/middleware-logger": "3.598.0",
+                "@aws-sdk/middleware-recursion-detection": "3.598.0",
+                "@aws-sdk/middleware-user-agent": "3.598.0",
+                "@aws-sdk/region-config-resolver": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@aws-sdk/util-user-agent-browser": "3.598.0",
+                "@aws-sdk/util-user-agent-node": "3.598.0",
+                "@smithy/config-resolver": "^3.0.2",
+                "@smithy/core": "^2.2.1",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/hash-node": "^3.0.1",
+                "@smithy/invalid-dependency": "^3.0.1",
+                "@smithy/middleware-content-length": "^3.0.1",
+                "@smithy/middleware-endpoint": "^3.0.2",
+                "@smithy/middleware-retry": "^3.0.4",
+                "@smithy/middleware-serde": "^3.0.1",
+                "@smithy/middleware-stack": "^3.0.1",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/url-parser": "^3.0.1",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.4",
+                "@smithy/util-defaults-mode-node": "^3.0.4",
+                "@smithy/util-endpoints": "^2.0.2",
+                "@smithy/util-middleware": "^3.0.1",
+                "@smithy/util-retry": "^3.0.1",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/core": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.598.0.tgz",
+            "integrity": "sha512-HaSjt7puO5Cc7cOlrXFCW0rtA0BM9lvzjl56x0A20Pt+0wxXGeTOZZOkXQIepbrFkV2e/HYukuT9e99vXDm59g==",
+            "requires": {
+                "@smithy/core": "^2.2.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/signature-v4": "^3.1.0",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/credential-provider-env": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.598.0.tgz",
+            "integrity": "sha512-vi1khgn7yXzLCcgSIzQrrtd2ilUM0dWodxj3PQ6BLfP0O+q1imO3hG1nq7DVyJtq7rFHs6+9N8G4mYvTkxby2w==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/credential-provider-http": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.598.0.tgz",
+            "integrity": "sha512-N7cIafi4HVlQvEgvZSo1G4T9qb/JMLGMdBsDCT5XkeJrF0aptQWzTFH0jIdZcLrMYvzPcuEyO3yCBe6cy/ba0g==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/fetch-http-handler": "^3.0.2",
+                "@smithy/node-http-handler": "^3.0.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/smithy-client": "^3.1.2",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-stream": "^3.0.2",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/credential-provider-ini": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.598.0.tgz",
+            "integrity": "sha512-/ppcIVUbRwDIwJDoYfp90X3+AuJo2mvE52Y1t2VSrvUovYn6N4v95/vXj6LS8CNDhz2jvEJYmu+0cTMHdhI6eA==",
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.598.0",
+                "@aws-sdk/credential-provider-http": "3.598.0",
+                "@aws-sdk/credential-provider-process": "3.598.0",
+                "@aws-sdk/credential-provider-sso": "3.598.0",
+                "@aws-sdk/credential-provider-web-identity": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/credential-provider-imds": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/credential-provider-node": {
+            "version": "3.600.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.600.0.tgz",
+            "integrity": "sha512-1pC7MPMYD45J7yFjA90SxpR0yaSvy+yZiq23aXhAPZLYgJBAxHLu0s0mDCk/piWGPh8+UGur5K0bVdx4B1D5hw==",
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.598.0",
+                "@aws-sdk/credential-provider-http": "3.598.0",
+                "@aws-sdk/credential-provider-ini": "3.598.0",
+                "@aws-sdk/credential-provider-process": "3.598.0",
+                "@aws-sdk/credential-provider-sso": "3.598.0",
+                "@aws-sdk/credential-provider-web-identity": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/credential-provider-imds": "^3.1.1",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/credential-provider-process": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.598.0.tgz",
+            "integrity": "sha512-rM707XbLW8huMk722AgjVyxu2tMZee++fNA8TJVNgs1Ma02Wx6bBrfIvlyK0rCcIRb0WdQYP6fe3Xhiu4e8IBA==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/credential-provider-sso": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.598.0.tgz",
+            "integrity": "sha512-5InwUmrAuqQdOOgxTccRayMMkSmekdLk6s+az9tmikq0QFAHUCtofI+/fllMXSR9iL6JbGYi1940+EUmS4pHJA==",
+            "requires": {
+                "@aws-sdk/client-sso": "3.598.0",
+                "@aws-sdk/token-providers": "3.598.0",
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.598.0.tgz",
+            "integrity": "sha512-GV5GdiMbz5Tz9JO4NJtRoFXjW0GPEujA0j+5J/B723rTN+REHthJu48HdBKouHGhdzkDWkkh1bu52V02Wprw8w==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/middleware-host-header": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.598.0.tgz",
+            "integrity": "sha512-WiaG059YBQwQraNejLIi0gMNkX7dfPZ8hDIhvMr5aVPRbaHH8AYF3iNSsXYCHvA2Cfa1O9haYXsuMF9flXnCmA==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/middleware-logger": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.598.0.tgz",
+            "integrity": "sha512-bxBjf/VYiu3zfu8SYM2S9dQQc3tz5uBAOcPz/Bt8DyyK3GgOpjhschH/2XuUErsoUO1gDJqZSdGOmuHGZQn00Q==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.598.0.tgz",
+            "integrity": "sha512-vjT9BeFY9FeN0f8hm2l6F53tI0N5bUq6RcDkQXKNabXBnQxKptJRad6oP2X5y3FoVfBLOuDkQgiC2940GIPxtQ==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/middleware-user-agent": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.598.0.tgz",
+            "integrity": "sha512-4tjESlHG5B5MdjUaLK7tQs/miUtHbb6deauQx8ryqSBYOhfHVgb1ZnzvQR0bTrhpqUg0WlybSkDaZAICf9xctg==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@aws-sdk/util-endpoints": "3.598.0",
+                "@smithy/protocol-http": "^4.0.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/region-config-resolver": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.598.0.tgz",
+            "integrity": "sha512-oYXhmTokSav4ytmWleCr3rs/1nyvZW/S0tdi6X7u+dLNL5Jee+uMxWGzgOrWK6wrQOzucLVjS4E/wA11Kv2GTw==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.1",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/token-providers": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.598.0.tgz",
+            "integrity": "sha512-TKY1EVdHVBnZqpyxyTHdpZpa1tUpb6nxVeRNn1zWG8QB5MvH4ALLd/jR+gtmWDNQbIG4cVuBOZFVL8hIYicKTA==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/property-provider": "^3.1.1",
+                "@smithy/shared-ini-file-loader": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/types": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+            "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
+            "requires": {
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/util-endpoints": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.598.0.tgz",
+            "integrity": "sha512-Qo9UoiVVZxcOEdiOMZg3xb1mzkTxrhd4qSlg5QQrfWPJVx/QOg+Iy0NtGxPtHtVZNHZxohYwDwV/tfsnDSE2gQ==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "@smithy/util-endpoints": "^2.0.2",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/util-locate-window": {
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+            "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.598.0.tgz",
+            "integrity": "sha512-36Sxo6F+ykElaL1mWzWjlg+1epMpSe8obwhCN1yGE7Js9ywy5U6k6l+A3q3YM9YRbm740sNxncbwLklMvuhTKw==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/types": "^3.1.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/util-user-agent-node": {
+            "version": "3.598.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.598.0.tgz",
+            "integrity": "sha512-oyWGcOlfTdzkC6SVplyr0AGh54IMrDxbhg5RxJ5P+V4BKfcDoDcZV9xenUk9NsOi9MuUjxMumb9UJGkDhM1m0A==",
+            "requires": {
+                "@aws-sdk/types": "3.598.0",
+                "@smithy/node-config-provider": "^3.1.1",
+                "@smithy/types": "^3.1.0",
+                "tslib": "^2.6.2"
+            }
+        },
         "@eslint-community/eslint-utils": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -3345,6 +5059,419 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
             "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
+        },
+        "@smithy/abort-controller": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
+            "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/config-resolver": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.4.tgz",
+            "integrity": "sha512-VwiOk7TwXoE7NlNguV/aPq1hFH72tqkHCw8eWXbr2xHspRyyv9DLpLXhq+Ieje+NwoqXrY0xyQjPXdOE6cGcHA==",
+            "requires": {
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/core": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.4.tgz",
+            "integrity": "sha512-qdY3LpMOUyLM/gfjjMQZui+UTNS7kBRDWlvyIhVOql5dn2J3isk9qUTBtQ1CbDH8MTugHis1zu3h4rH+Qmmh4g==",
+            "requires": {
+                "@smithy/middleware-endpoint": "^3.0.4",
+                "@smithy/middleware-retry": "^3.0.7",
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/smithy-client": "^3.1.5",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/credential-provider-imds": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.3.tgz",
+            "integrity": "sha512-U1Yrv6hx/mRK6k8AncuI6jLUx9rn0VVSd9NPEX6pyYFBfkSkChOc/n4zUb8alHUVg83TbI4OdZVo1X0Zfj3ijA==",
+            "requires": {
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/fetch-http-handler": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.0.tgz",
+            "integrity": "sha512-vFvDxMrc6sO5Atec8PaISckMcAwsCrRhYxwUylg97bRT2KZoumOF7qk5+6EVUtuM1IG9AJV5aqXnHln9ZdXHpg==",
+            "requires": {
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/hash-node": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
+            "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/invalid-dependency": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
+            "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/is-array-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+            "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/middleware-content-length": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.3.tgz",
+            "integrity": "sha512-Dbz2bzexReYIQDWMr+gZhpwBetNXzbhnEMhYKA6urqmojO14CsXjnsoPYO8UL/xxcawn8ZsuVU61ElkLSltIUQ==",
+            "requires": {
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/middleware-endpoint": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.4.tgz",
+            "integrity": "sha512-whUJMEPwl3ANIbXjBXZVdJNgfV2ZU8ayln7xUM47rXL2txuenI7jQ/VFFwCzy5lCmXScjp6zYtptW5Evud8e9g==",
+            "requires": {
+                "@smithy/middleware-serde": "^3.0.3",
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/url-parser": "^3.0.3",
+                "@smithy/util-middleware": "^3.0.3",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/middleware-retry": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.7.tgz",
+            "integrity": "sha512-f5q7Y09G+2h5ivkSx5CHvlAT4qRR3jBFEsfXyQ9nFNiWQlr8c48blnu5cmbTQ+p1xmIO14UXzKoF8d7Tm0Gsjw==",
+            "requires": {
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/smithy-client": "^3.1.5",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-retry": "^3.0.3",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+                    "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+                }
+            }
+        },
+        "@smithy/middleware-serde": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
+            "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/middleware-stack": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
+            "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/node-config-provider": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.3.tgz",
+            "integrity": "sha512-rxdpAZczzholz6CYZxtqDu/aKTxATD5DAUDVj7HoEulq+pDSQVWzbg0btZDlxeFfa6bb2b5tUvgdX5+k8jUqcg==",
+            "requires": {
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/shared-ini-file-loader": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/node-http-handler": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.1.tgz",
+            "integrity": "sha512-L71NLyPeP450r2J/mfu1jMc//Z1YnqJt2eSNw7uhiItaONnBLDA68J5jgxq8+MBDsYnFwNAIc7dBG1ImiWBiwg==",
+            "requires": {
+                "@smithy/abort-controller": "^3.1.1",
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/querystring-builder": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/property-provider": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
+            "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/protocol-http": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.3.tgz",
+            "integrity": "sha512-x5jmrCWwQlx+Zv4jAtc33ijJ+vqqYN+c/ZkrnpvEe/uDas7AT7A/4Rc2CdfxgWv4WFGmEqODIrrUToPN6DDkGw==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/querystring-builder": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
+            "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/querystring-parser": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
+            "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/service-error-classification": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
+            "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
+            "requires": {
+                "@smithy/types": "^3.3.0"
+            }
+        },
+        "@smithy/shared-ini-file-loader": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.3.tgz",
+            "integrity": "sha512-Z8Y3+08vgoDgl4HENqNnnzSISAaGrF2RoKupoC47u2wiMp+Z8P/8mDh1CL8+8ujfi2U5naNvopSBmP/BUj8b5w==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/signature-v4": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
+            "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
+            "requires": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.3",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/smithy-client": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.5.tgz",
+            "integrity": "sha512-x9bL9Mx2CT2P1OiUlHM+ZNpbVU6TgT32f9CmTRzqIHA7M4vYrROCWEoC3o4xHNJASoGd4Opos3cXYPgh+/m4Ww==",
+            "requires": {
+                "@smithy/middleware-endpoint": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.3",
+                "@smithy/protocol-http": "^4.0.3",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-stream": "^3.0.5",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/types": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/url-parser": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
+            "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
+            "requires": {
+                "@smithy/querystring-parser": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-base64": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+            "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+            "requires": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-body-length-browser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+            "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-body-length-node": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+            "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-buffer-from": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+            "requires": {
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-config-provider": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+            "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-defaults-mode-browser": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.7.tgz",
+            "integrity": "sha512-Q2txLyvQyGfmjsaDbVV7Sg8psefpFcrnlGapDzXGFRPFKRBeEg6OvFK8FljqjeHSaCZ6/UuzQExUPqBR/2qlDA==",
+            "requires": {
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.1.5",
+                "@smithy/types": "^3.3.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-defaults-mode-node": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.7.tgz",
+            "integrity": "sha512-F4Qcj1fG6MGi2BSWCslfsMSwllws/WzYONBGtLybyY+halAcXdWhcew+mej8M5SKd5hqPYp4f7b+ABQEaeytgg==",
+            "requires": {
+                "@smithy/config-resolver": "^3.0.4",
+                "@smithy/credential-provider-imds": "^3.1.3",
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/property-provider": "^3.1.3",
+                "@smithy/smithy-client": "^3.1.5",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-endpoints": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.4.tgz",
+            "integrity": "sha512-ZAtNf+vXAsgzgRutDDiklU09ZzZiiV/nATyqde4Um4priTmasDH+eLpp3tspL0hS2dEootyFMhu1Y6Y+tzpWBQ==",
+            "requires": {
+                "@smithy/node-config-provider": "^3.1.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-hex-encoding": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+            "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-middleware": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
+            "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
+            "requires": {
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-retry": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
+            "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
+            "requires": {
+                "@smithy/service-error-classification": "^3.0.3",
+                "@smithy/types": "^3.3.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-stream": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.5.tgz",
+            "integrity": "sha512-xC3L5PKMAT/Bh8fmHNXP9sdQ4+4aKVUU3EEJ2CF/lLk7R+wtMJM+v/1B4en7jO++Wa5spGzFDBCl0QxgbUc5Ug==",
+            "requires": {
+                "@smithy/fetch-http-handler": "^3.2.0",
+                "@smithy/node-http-handler": "^3.1.1",
+                "@smithy/types": "^3.3.0",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-uri-escape": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+            "requires": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-utf8": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+            "requires": {
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
         },
         "@szmarczak/http-timer": {
             "version": "4.0.6",
@@ -3574,6 +5701,11 @@
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
+        },
+        "bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -4173,6 +6305,14 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
+        },
+        "fast-xml-parser": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+            "requires": {
+                "strnum": "^1.0.5"
+            }
         },
         "fastq": {
             "version": "1.15.0",
@@ -5350,6 +7490,11 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
+        "strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
         "supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5431,9 +7576,9 @@
             }
         },
         "tslib": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-            "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "tunnel-agent": {
             "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     },
     "license": "Apache-2.0",
     "dependencies": {
+        "@aws-sdk/client-efs": "^3.600.0",
         "@kubernetes/client-node": "^0.18.1",
         "got": "^11.8.0",
         "lodash": "^4.17.21"

--- a/templates.js
+++ b/templates.js
@@ -1,0 +1,171 @@
+const deploymentTemplate = {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+        // name: "k8s-client-test-deployment",
+        labels: {
+            // name: "k8s-client-test-deployment",
+            nodered: 'true'
+            // app: "k8s-client-test-deployment"
+        }
+    },
+    spec: {
+        replicas: 1,
+        selector: {
+            matchLabels: {
+                // app: "k8s-client-test-deployment"
+            }
+        },
+        template: {
+            metadata: {
+                labels: {
+                    // name: "k8s-client-test-deployment",
+                    nodered: 'true'
+                    // app: "k8s-client-test-deployment"
+                }
+            },
+            spec: {
+                securityContext: {
+                    runAsUser: 1000,
+                    runAsGroup: 1000,
+                    fsGroup: 1000
+                },
+                containers: [
+                    {
+                        resources: {
+                            requests: {
+                                // 10th of a core
+                                cpu: '100m',
+                                memory: '128Mi'
+                            },
+                            limits: {
+                                cpu: '125m',
+                                memory: '192Mi'
+                            }
+                        },
+                        name: 'node-red',
+                        // image: "docker-pi.local:5000/bronze-node-red",
+                        imagePullPolicy: 'Always',
+                        env: [
+                            // {name: "APP_NAME", value: "test"},
+                            { name: 'TZ', value: 'Europe/London' }
+                        ],
+                        ports: [
+                            { name: 'web', containerPort: 1880, protocol: 'TCP' },
+                            { name: 'management', containerPort: 2880, protocol: 'TCP' }
+                        ],
+                        securityContext: {
+                            allowPrivilegeEscalation: false
+                        }
+                    }
+                ]
+            },
+            enableServiceLinks: false
+        }
+    }
+}
+
+const serviceTemplate = {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+        // name: "k8s-client-test-service"
+    },
+    spec: {
+        type: 'ClusterIP',
+        selector: {
+            // name: "k8s-client-test"
+        },
+        ports: [
+            { name: 'web', port: 1880, protocol: 'TCP' },
+            { name: 'management', port: 2880, protocol: 'TCP' }
+        ]
+    }
+}
+
+const ingressTemplate = {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'Ingress',
+    metadata: {
+        // name: "k8s-client-test-ingress",
+        // namespace: 'flowforge',
+        annotations: process.env.INGRESS_ANNOTATIONS ? JSON.parse(process.env.INGRESS_ANNOTATIONS) : {}
+    },
+    spec: {
+        ingressClassName: process.env.INGRESS_CLASS_NAME ? process.env.INGRESS_CLASS_NAME : null,
+        rules: [
+            {
+                // host: "k8s-client-test" + "." + "ubuntu.local",
+                http: {
+                    paths: [
+                        {
+                            pathType: 'Prefix',
+                            path: '/',
+                            backend: {
+                                service: {
+                                    // name: 'k8s-client-test-service',
+                                    port: { number: 1880 }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}
+
+const customIngressTemplate = {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'Ingress',
+    metadata: {
+        annotations: {}
+    },
+    spec: {
+        rules: [
+            {
+                http: {
+                    paths: [
+                        {
+                            pathType: 'Prefix',
+                            path: '/',
+                            backend: {
+                                service: {
+                                    port: { number: 1880 }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        tls: [
+
+        ]
+    }
+}
+
+const persistentVolumeClaimTemplate = {
+    apiVersion: 'v1',
+    kind: 'PersistentVolumeClaim',
+    metadata: {
+
+    },
+    spec: {
+        accessModes: [
+            'ReadWriteMany' // picked for HA mode
+        ],
+        resources: {
+            requests: {
+            }
+        }
+    }
+}
+
+module.exports = {
+    deploymentTemplate,
+    serviceTemplate,
+    ingressTemplate,
+    customIngressTemplate,
+    persistentVolumeClaimTemplate
+}


### PR DESCRIPTION
fixes FlowFuse/flowfuse#4003

## Description

<!-- Describe your changes in detail -->
Adds support for mounting a PVC on `/data/storage` to allow for using the standard filesystem nodes.

Also refactors all K8s templates into their own file to make things a little cleaner.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#4003

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

