### PR TITLE
feat: Add possibility to specify custom pod security context

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ driver:
       enabled: true
       storageClass: nfs-storage
       size: 5Gi
+    podSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
 ```
 
 - `registry` is the Docker Registry to load Stack Containers from
@@ -52,6 +56,7 @@ AWS EKS specific annotation for ALB Ingress. or `openshift` to allow running on 
 - `storage.storageClass` Name of StorageClass to use to allocate the volume (default not set)
 - `storage.storageClassEFSTag` Used instead of `storage.storageClass` when needing to shard across multiple EFS file systems (default not set)
 - `storage.size` Size of the volume to request (default not set)
+- `podSecurityContext` Settings linked to the [security context of the pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
 
 Expects to pick up K8s credentials from the environment
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -181,10 +181,6 @@ const createDeployment = async (project, options) => {
         }
     }
 
-    if (this._app.license.active() && this._cloudProvider === 'openshift') {
-        localPod.spec.securityContext = {}
-    }
-
     if (this._app.config.driver.options?.podSecurityContext) {
         localPod.spec.securityContext = this._app.config.driver.options.podSecurityContext
     }

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -183,6 +183,8 @@ const createDeployment = async (project, options) => {
 
     if (this._app.config.driver.options?.podSecurityContext) {
         localPod.spec.securityContext = this._app.config.driver.options.podSecurityContext
+    } else if (this._app.license.active() && this._cloudProvider === 'openshift') {
+        localPod.spec.securityContext = {}
     }
 
     if (stack.memory && stack.cpu) {

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -185,6 +185,10 @@ const createDeployment = async (project, options) => {
         localPod.spec.securityContext = {}
     }
 
+    if (this._app.config.driver.options?.podSecurityContext) {
+        localPod.spec.securityContext = this._app.config.driver.options.podSecurityContext
+    }
+
     if (stack.memory && stack.cpu) {
         localPod.spec.containers[0].resources.requests.memory = `${stack.memory}Mi`
         // increase limit to give npm more room to run in


### PR DESCRIPTION
## Description

This pull request adds the possibility of specifying a custom [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for launched deployments.

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/526

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

