### PR TITLE
Only restart active MQTT Agents

### DIFF
--- a/kubernetes.js
+++ b/kubernetes.js
@@ -684,7 +684,7 @@ module.exports = {
 
                 // Check restarting MQTT-Schema-Agent
                 brokers.forEach(async (broker) => {
-                    if (broker.Team) {
+                    if (broker.Team && broker.state === 'running') {
                         try {
                             this._app.log.info(`[k8s] Testing MQTT Agent ${broker.hashid} in ${namespace} pod exists`)
                             this._app.log.debug(`mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${broker.hashid.toLowerCase()}`)


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Add check to only restart MQTT Schema agents that are in running state if missing on start up.