### PR TITLE
feat: Add possibility to customise service type created for project deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ AWS EKS specific annotation for ALB Ingress. or `openshift` to allow running on 
 - `storage.storageClassEFSTag` Used instead of `storage.storageClass` when needing to shard across multiple EFS file systems (default not set)
 - `storage.size` Size of the volume to request (default not set)
 - `podSecurityContext` Settings linked to the [security context of the pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-- `service.type` Type of service to create for the editor (default `ClusterIP`)
+- `service.type` Type of service to create for the editor (allowed `ClusterIP` or `NodePort`, default `ClusterIP`)
 
 Expects to pick up K8s credentials from the environment
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ AWS EKS specific annotation for ALB Ingress. or `openshift` to allow running on 
 - `storage.storageClassEFSTag` Used instead of `storage.storageClass` when needing to shard across multiple EFS file systems (default not set)
 - `storage.size` Size of the volume to request (default not set)
 - `podSecurityContext` Settings linked to the [security context of the pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- `service.type` Type of service to create for the editor (default `ClusterIP`)
 
 Expects to pick up K8s credentials from the environment
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -216,6 +216,15 @@ const createService = async (project, options) => {
     const localService = JSON.parse(JSON.stringify(serviceTemplate))
     localService.metadata.name = `${prefix}${project.safeName}`
     localService.spec.selector.name = project.safeName
+    const allowedServiceTypes = ['NodePort', 'ClusterIP']
+    const serviceType = this._app.config.driver.options?.service?.type || 'ClusterIP'
+    if (!allowedServiceTypes.includes(serviceType)) {
+        throw new Error('Service type must be either NodePort or ClusterIP')
+    }
+    localService.spec.type = serviceType
+    if (serviceType === 'NodePort' && this._app.config.driver.options?.service?.nodePort) {
+        localService.spec.ports[0].nodePort = this._app.config.driver.options?.service?.nodePort
+    }
     return localService
 }
 

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -222,9 +222,6 @@ const createService = async (project, options) => {
         throw new Error('Service type must be either NodePort or ClusterIP')
     }
     localService.spec.type = serviceType
-    if (serviceType === 'NodePort' && this._app.config.driver.options?.service?.nodePort) {
-        localService.spec.ports[0].nodePort = this._app.config.driver.options?.service?.nodePort
-    }
     return localService
 }
 

--- a/templates.js
+++ b/templates.js
@@ -72,7 +72,6 @@ const serviceTemplate = {
         // name: "k8s-client-test-service"
     },
     spec: {
-        type: 'ClusterIP',
         selector: {
             // name: "k8s-client-test"
         },


### PR DESCRIPTION
## Description

This pull request adds a possibility to define service type which is created for NodeRED instance deployment. Currently, only `ClusterIP` (default) and `NodePort` service types are supported.

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/4041

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

