### PR TITLE
feat: add possibility to apply custom labels on project-related resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ driver:
     projectSelector:
       role: projects
     projectNamespace: flowforge
+    projectLabels:
+      environment: production
+      team: alpha
     cloudProvider: aws
     privateCA: ff-ca-certs
     certManagerIssuer: lets-encrypt
@@ -40,6 +43,7 @@ driver:
 - `projectNamespace` the namespace Project pods should run in
 - `projectSelector` a list of labels that should be used to select which nodes Project Pods
 should run on
+- `projectLabels` a list of custom labels that should be applied to all resources created for Projects (Pods, Services, Ingresses, PVCs)
 - `cloudProvider` normally not set, but can be `aws` This triggers the adding of
 AWS EKS specific annotation for ALB Ingress. or `openshift` to allow running on OpenShift (Enterprise license only)
 - `privateCA` name of ConfigMap holding PEM CA Cert Bundle (file name `certs.pem`) Optional

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -203,8 +203,12 @@ const createDeployment = async (project, options) => {
     }
 
     if (this._app.config.driver.options?.projectLabels) {
-        localPod.spec.labels = {
-            ...localPod.spec.labels,
+        localPod.metadata.labels = {
+            ...localPod.metadata.labels,
+            ...this._app.config.driver.options.projectLabels
+        }
+        localDeployment.metadata.labels = {
+            ...localDeployment.metadata.labels,
             ...this._app.config.driver.options.projectLabels
         }
     }
@@ -578,8 +582,8 @@ const createMQTTTopicAgent = async (broker) => {
         broker: agent ? 'team-broker' : broker.hashid
     }
     if (this._app.config.driver.options?.projectLabels) {
-        localPod.spec.labels = {
-            ...localPod.spec.labels,
+        localPod.metadata.labels = {
+            ...localPod.metadata.labels,
             ...this._app.config.driver.options.projectLabels
         }
         localService.metadata.labels = {

--- a/kubernetes.js
+++ b/kubernetes.js
@@ -202,6 +202,13 @@ const createDeployment = async (project, options) => {
         localPod.spec.containers[0].resources.limits.cpu = `${stack.cpu * 10}m`
     }
 
+    if (this._app.config.driver.options?.projectLabels) {
+        localPod.spec.labels = {
+            ...localPod.spec.labels,
+            ...this._app.config.driver.options.projectLabels
+        }
+    }
+
     const ha = await project.getSetting('ha')
     if (ha?.replicas > 1) {
         localDeployment.spec.replicas = ha.replicas
@@ -225,6 +232,9 @@ const createService = async (project, options) => {
         throw new Error('Service type must be either NodePort or ClusterIP')
     }
     localService.spec.type = serviceType
+    if (this._app.config.driver.options?.projectLabels) {
+        localService.metadata.labels = this._app.config.driver.options.projectLabels
+    }
     return localService
 }
 
@@ -263,6 +273,10 @@ const createIngress = async (project, options) => {
     Object.keys(localIngress.metadata.annotations).forEach((key) => {
         localIngress.metadata.annotations[key] = mustache(localIngress.metadata.annotations[key], exposedData)
     })
+
+    if (this._app.config.driver.options?.projectLabels) {
+        localIngress.metadata.labels = this._app.config.driver.options.projectLabels
+    }
 
     localIngress.metadata.name = project.safeName
     localIngress.spec.rules[0].host = url.host
@@ -312,6 +326,10 @@ const createCustomIngress = async (project, hostname, options) => {
         customIngress.spec.ingressClassName = `${this._customHostname.ingressClass}`
     }
 
+    if (this._app.config.driver.options?.projectLabels) {
+        customIngress.metadata.labels = this._app.config.driver.options.projectLabels
+    }
+
     return customIngress
 }
 
@@ -336,6 +354,12 @@ const createPersistentVolumeClaim = async (project, options) => {
     pvc.metadata.labels = {
         'ff-project-id': project.id,
         'ff-project-name': project.safeName
+    }
+    if (this._app.config.driver.options?.projectLabels) {
+        pvc.metadata.labels = {
+            ...pvc.metadata.labels,
+            ...this._app.config.driver.options.projectLabels
+        }
     }
     console.log(`PVC: ${JSON.stringify(pvc, null, 2)}`)
     return pvc
@@ -552,6 +576,16 @@ const createMQTTTopicAgent = async (broker) => {
     localService.metadata.labels = {
         team: broker.Team.hashid,
         broker: agent ? 'team-broker' : broker.hashid
+    }
+    if (this._app.config.driver.options?.projectLabels) {
+        localPod.spec.labels = {
+            ...localPod.spec.labels,
+            ...this._app.config.driver.options.projectLabels
+        }
+        localService.metadata.labels = {
+            ...localService.metadata.labels,
+            ...this._app.config.driver.options.projectLabels
+        }
     }
     localService.spec.selector.name = `mqtt-schema-agent-${broker.Team.hashid.toLowerCase()}-${agent ? 'team-broker' : broker.hashid.toLowerCase()}`
 


### PR DESCRIPTION
## Description

This pull request adds an option to provide a list of custom labels, via `projectLabels` configuration parameter, that will be applied to all project-related resources. 

## Related Issue(s)

https://github.com/FlowFuse/helm/issues/682

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

